### PR TITLE
Add context menus to set color/brightness

### DIFF
--- a/Widget/LightTargetCollectionViewItem.swift
+++ b/Widget/LightTargetCollectionViewItem.swift
@@ -59,4 +59,40 @@ class LightTargetCollectionViewItem: NSCollectionViewItem, LightTargetControlVie
 	func controlViewDidGetClicked(view: LightTargetControlView) {
 		lightTarget.setPower(!lightTarget.power, duration: 0.5)
 	}
+
+    func controlViewDidSetColor(view: NSMenuItem) {
+        let color_string = view.representedObject as? String
+
+        var mapping = [
+            "Hot White": Color.white(2500),
+            "Warm White": Color.white(3500),
+            "Cool White": Color.white(4500),
+            "Cold White": Color.white(5500),
+            "Blue White": Color.white(9000),
+            "Red":        Color.color(0,   saturation: 1),
+            "Orange":     Color.color(40,  saturation: 1),
+            "Yellow":     Color.color(60,  saturation: 1),
+            "Green":      Color.color(120, saturation: 1),
+            "Cyan":       Color.color(180, saturation: 1),
+            "Blue":       Color.color(240, saturation: 1),
+            "Purple":     Color.color(280, saturation: 1),
+            "Pink":       Color.color(320, saturation: 1),
+        ]
+
+        lightTarget.setColor(mapping[color_string!]!, duration: 0.5)
+    }
+
+    func controlViewDidSetBrightness(view: NSMenuItem) {
+        let brightness = view.representedObject as? String
+        var mapping = [
+            "100%": 1.0,
+            "80%":  0.8,
+            "60%":  0.6,
+            "40%":  0.4,
+            "20%":  0.2,
+        ]
+
+        lightTarget.setBrightness(mapping[brightness!]!, duration: 0.5)
+    }
+
 }

--- a/Widget/LightTargetControlView.swift
+++ b/Widget/LightTargetControlView.swift
@@ -6,7 +6,9 @@
 import Cocoa
 
 protocol LightTargetControlViewDelegate: class {
-	func controlViewDidGetClicked(view: LightTargetControlView)
+    func controlViewDidGetClicked(view: LightTargetControlView)
+    func controlViewDidSetColor(view: NSMenuItem)
+    func controlViewDidSetBrightness(view: NSMenuItem)
 }
 
 class LightTargetControlView: NSView {
@@ -89,7 +91,78 @@ class LightTargetControlView: NSView {
 		}
 	}
 
+    override func rightMouseDown(theEvent: NSEvent) {
+
+    }
+
+    override func rightMouseUp(theEvent: NSEvent) {
+        if enabled {
+            let mainMenu = NSMenu(title: "Context menu")
+            mainMenu.autoenablesItems = false
+
+            var brightnessMenu = addSubmenu("Brightness", mainMenu: mainMenu)
+            brightnessMenu.addItem(brightnessItemFor("100%"))
+            brightnessMenu.addItem(brightnessItemFor("80%"))
+            brightnessMenu.addItem(brightnessItemFor("60%"))
+            brightnessMenu.addItem(brightnessItemFor("40%"))
+            brightnessMenu.addItem(brightnessItemFor("20%"))
+
+            var whitesMenu = addSubmenu("Whites", mainMenu: mainMenu)
+            whitesMenu.addItem(colorItemFor("Hot White"))
+            whitesMenu.addItem(colorItemFor("Warm White"))
+            whitesMenu.addItem(colorItemFor("Cool White"))
+            whitesMenu.addItem(colorItemFor("Cold White"))
+            whitesMenu.addItem(colorItemFor("Blue White"))
+
+
+            var colorsMenu = addSubmenu("Colors", mainMenu: mainMenu)
+            colorsMenu.addItem(colorItemFor("Red"))
+            colorsMenu.addItem(colorItemFor("Blue"))
+            colorsMenu.addItem(colorItemFor("Green"))
+            colorsMenu.addItem(colorItemFor("Orange"))
+            colorsMenu.addItem(colorItemFor("Yellow"))
+            colorsMenu.addItem(colorItemFor("Cyan"))
+            colorsMenu.addItem(colorItemFor("Purple"))
+            colorsMenu.addItem(colorItemFor("Pink"))
+
+            NSMenu.popUpContextMenu(mainMenu, withEvent: theEvent, forView: self)
+        }
+    }
+
 	override func mouseDragged(theEvent: NSEvent) {
 
 	}
+
+    // Menu creation helpers
+
+    func addSubmenu(title: String, mainMenu: NSMenu) -> NSMenu {
+        var submenuItem = NSMenuItem(title: title, action:nil, keyEquivalent: "")
+        var submenu = NSMenu()
+        mainMenu.setSubmenu(submenu, forItem: submenuItem)
+        mainMenu.addItem(submenuItem)
+        return submenu
+    }
+
+    func colorItemFor(title: String) -> NSMenuItem{
+        var menuItem = NSMenuItem()
+        menuItem.title = title
+        menuItem.action = "controlViewDidSetColor:"
+        menuItem.target = delegate
+        menuItem.keyEquivalent = ""
+        menuItem.representedObject = title
+        menuItem.enabled = true
+        return menuItem
+    }
+
+    func brightnessItemFor(title: String) -> NSMenuItem{
+        var menuItem = NSMenuItem()
+        menuItem.title = title
+        menuItem.action = "controlViewDidSetBrightness:"
+        menuItem.target = delegate
+        menuItem.keyEquivalent = ""
+        menuItem.representedObject = title
+        menuItem.enabled = true
+        return menuItem
+    }
+
 }


### PR DESCRIPTION
I hacked for a bit to get some right-click menus to set a few basic whites, a few brightnesses and some colours and came up with this.

I dont actually really know anything about Swift or OS X programming so I'm sure this probably needs some cleaning up to fit with idioms of the platform, but it seems to work as it is.